### PR TITLE
Separate agenda handling from the "soon" SLO.

### DIFF
--- a/frontend/src/components/Issue.astro
+++ b/frontend/src/components/Issue.astro
@@ -1,30 +1,54 @@
 ---
 import { formatRoundAge } from "@lib/formatRoundAge";
 import type { IssueSummary } from "@lib/repo-summaries";
-import { slo, sloMap } from "@lib/slo";
+import { agendaSLO, slo, sloMap } from "@lib/slo";
+import assert from "node:assert";
 
 interface Props {
     issue: IssueSummary;
+    // Show the issue's time on the agenda rather than its prioritized SLO time.
+    agenda?: boolean;
 }
-const { issue } = Astro.props;
+const { issue, agenda } = Astro.props;
 
-const { withinSlo } = slo(issue);
+const { withinSlo, onAgendaTooLong } = slo(issue);
 
-let timeToReport = issue.sloTimeUsed;
-if (!withinSlo) {
-    if (issue.whichSlo === "none") {
-        throw new Error(
-            `Can't be out of SLO with a 'none' SLO type: ${JSON.stringify(
-                issue
-            )}`
-        );
+const timeToReport = (function () {
+    if (agenda) {
+        assert(issue.onAgendaFor);
+        if (onAgendaTooLong) {
+            return issue.onAgendaFor.subtract(agendaSLO);
+        }
+        return issue.onAgendaFor;
+    } else {
+        if (withinSlo) {
+            return issue.sloTimeUsed;
+        } else {
+            if (issue.whichSlo === "none") {
+                throw new Error(
+                    `Can't be out of SLO with a 'none' SLO type: ${JSON.stringify(
+                        issue
+                    )}`
+                );
+            }
+            return issue.sloTimeUsed.subtract(sloMap[issue.whichSlo]);
+        }
     }
-    timeToReport = issue.sloTimeUsed.subtract(sloMap[issue.whichSlo]);
-}
+})();
 ---
 
 <a href={issue.url}>{issue.title}</a>: {
-    withinSlo ? "on maintainers' plate" : <span class="error">out of SLO</span>
+    agenda ? (
+        onAgendaTooLong ? (
+            <span class="error">out of SLO</span>
+        ) : (
+            "on the agenda"
+        )
+    ) : withinSlo ? (
+        "on maintainers' plate"
+    ) : (
+        <span class="error">out of SLO</span>
+    )
 } for {formatRoundAge(timeToReport)}
 
 <style is:global>

--- a/frontend/src/lib/published-json.ts
+++ b/frontend/src/lib/published-json.ts
@@ -6,9 +6,11 @@ export const SummaryJson = z.object({}).catchall(z.object({
         triageViolations: z.number(),
         urgentViolations: z.number(),
         soonViolations: z.number(),
+        agendaViolations: z.number(),
         needTriage: z.number(),
         urgent: z.number(),
         soon: z.number(),
+        agenda: z.number(),
         other: z.number(),
     }));
 export type SummaryJson = z.infer<typeof SummaryJson>;
@@ -22,14 +24,17 @@ export const RepoJson = z.object({
         triageViolations: z.number(),
         urgentViolations: z.number(),
         soonViolations: z.number(),
+        agendaViolations: z.number(),
         needTriage: z.number(),
         urgent: z.number(),
         soon: z.number(),
+        agenda: z.number(),
         other: z.number(),
     }),
     triage: IssueSummaryWithSlo.array(),
     urgent: IssueSummaryWithSlo.array(),
     soon: IssueSummaryWithSlo.array(),
+    agenda: IssueSummaryWithSlo.array(),
     other: IssueSummaryWithSlo.array(),
 });
 export type RepoJson = z.infer<typeof RepoJson>;

--- a/frontend/src/lib/repo-summaries.ts
+++ b/frontend/src/lib/repo-summaries.ts
@@ -18,6 +18,8 @@ export const IssueSummaryInContent = z.object({
     }).optional(),
     sloTimeUsed: checkDuration,
     whichSlo: SloType,
+    // For Agenda+ issues, this is how long since the label was most-recently added.
+    onAgendaFor: checkDuration.optional(),
     stats: z.object({
         numTimelineItems: z.number(),
         numComments: z.number().optional(),
@@ -29,6 +31,7 @@ export type IssueSummaryInContent = z.infer<typeof IssueSummaryInContent>;
 export const IssueSummary = IssueSummaryInContent.extend({
     createdAt: instant,
     sloTimeUsed: duration,
+    onAgendaFor: duration.optional(),
 });
 export type IssueSummary = z.infer<typeof IssueSummary>;
 

--- a/frontend/src/pages/[org]/[repo].astro
+++ b/frontend/src/pages/[org]/[repo].astro
@@ -3,7 +3,7 @@ import GhLabel from "@components/GhLabel.astro";
 import Issue from "@components/Issue.astro";
 import Layout from "@layouts/Layout.astro";
 import { IssueSummary } from "@lib/repo-summaries";
-import { cmpByTimeUsed, groupBySlo } from "@lib/slo";
+import { cmpByAgendaUsed, cmpByTimeUsed, groupBySlo } from "@lib/slo";
 import * as ghLabels from "@lib/triage-labels";
 import type {
 GetStaticPaths,
@@ -29,6 +29,8 @@ const { details } = Astro.props as Props;
 const {
     untriaged,
     triageViolations,
+    agenda,
+    agendaViolations,
     soon,
     soonViolations,
     urgent,
@@ -38,6 +40,8 @@ urgent.push(...urgentViolations);
 urgent.sort(cmpByTimeUsed);
 soon.push(...soonViolations);
 soon.sort(cmpByTimeUsed);
+agenda.push(...agendaViolations);
+agenda.sort(cmpByAgendaUsed);
 untriaged.push(...triageViolations);
 untriaged.sort(cmpByTimeUsed);
 ---
@@ -85,6 +89,17 @@ untriaged.sort(cmpByTimeUsed);
             ) : null
         }
         {
+            agenda.length > 0 ? (
+                <li>
+                    <a href="#agenda">
+                        {agendaViolations.length
+                            ? `${agendaViolations.length} issues on the agenda that have been waiting too long`
+                            : `${agenda.length} issues on the agenda`}
+                    </a>
+                </li>
+            ) : null
+        }
+        {
             soon.length > 0 ? (
                 <li>
                     <a href="#soon">
@@ -120,6 +135,21 @@ untriaged.sort(cmpByTimeUsed);
                     {urgent.map((issue) => (
                         <li>
                             <Issue {issue} />
+                        </li>
+                    ))}
+                </ul>
+            </>
+        ) : null
+    }
+
+    {
+        agenda.length > 0 ? (
+            <>
+                <h2 id="agenda">Agenda</h2>
+                <ul>
+                    {agenda.map((issue) => (
+                        <li>
+                            <Issue {issue} agenda />
                         </li>
                     ))}
                 </ul>

--- a/frontend/src/pages/[org]/[repo].json.ts
+++ b/frontend/src/pages/[org]/[repo].json.ts
@@ -29,14 +29,17 @@ export const GET: APIRoute = ({ props }) => {
             triageViolations: groups.triageViolations.length,
             urgentViolations: groups.urgentViolations.length,
             soonViolations: groups.soonViolations.length,
+            agendaViolations: groups.agendaViolations.length,
             needTriage: groups.untriaged.length,
             urgent: groups.urgent.length,
             soon: groups.soon.length,
+            agenda: groups.agenda.length,
             other: groups.other.length,
         },
         triage: groups.triageViolations.map(issue => Object.assign(issue, outOfSloObj)).concat(groups.untriaged),
         urgent: groups.urgentViolations.map(issue => Object.assign(issue, outOfSloObj)).concat(groups.urgent),
         soon: groups.soonViolations.map(issue => Object.assign(issue, outOfSloObj)).concat(groups.soon),
+        agenda: groups.agendaViolations.map(issue => Object.assign(issue, outOfSloObj)).concat(groups.agenda),
         other: groups.other,
     } satisfies RepoJson;
     return new Response(JSON.stringify(summary));

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import GhLabel from "@components/GhLabel.astro";
 import { IssueSummary } from "@lib/repo-summaries";
-import { groupBySlo } from "@lib/slo";
+import { agendaSLO, groupBySlo, soonSLO, triageSLO, urgentSLO } from "@lib/slo";
 import * as ghLabels from "@lib/triage-labels";
 import { getCollection } from "astro:content";
 import Layout from "../layouts/Layout.astro";
@@ -11,9 +11,11 @@ const repos = await getCollection("github");
 let totalTriageViolations = 0;
 let totalUrgentViolations = 0;
 let totalSoonViolations = 0;
+let totalAgendaViolations = 0;
 let totalNeedTriage = 0;
 let totalUrgent = 0;
 let totalSoon = 0;
+let totalAgenda = 0;
 let totalOther = 0;
 
 const andFormatter = new Intl.ListFormat("en", {
@@ -27,17 +29,21 @@ const repoSummaries = repos.map((repo) => {
     const triageViolations = groups.triageViolations.length;
     const urgentViolations = groups.urgentViolations.length;
     const soonViolations = groups.soonViolations.length;
+    const agendaViolations = groups.agendaViolations.length;
     const needTriage = groups.untriaged.length;
     const urgent = groups.urgent.length;
     const soon = groups.soon.length;
+    const agenda = groups.agenda.length;
     const other = groups.other.length;
 
     totalTriageViolations += triageViolations;
     totalUrgentViolations += urgentViolations;
     totalSoonViolations += soonViolations;
+    totalAgendaViolations += agendaViolations;
     totalNeedTriage += needTriage;
     totalUrgent += urgent;
     totalSoon += soon;
+    totalAgenda += agenda;
     totalOther += other;
 
     let message: string[] = [];
@@ -48,8 +54,13 @@ const repoSummaries = repos.map((repo) => {
         if (urgentViolations > 0) {
             message.push(`${urgentViolations} urgent SLO violations`);
         }
-    } else if (soonViolations > 0) {
-        message.push(`${soonViolations} soon SLO violations`);
+    } else if (soonViolations > 0 || agendaViolations > 0) {
+        if (soonViolations > 0) {
+            message.push(`${soonViolations} soon SLO violations`);
+        }
+        if (agendaViolations > 0) {
+            message.push(`${agendaViolations} agenda SLO violations`);
+        }
     } else if (needTriage > 0 || urgent > 0) {
         if (needTriage > 0) {
             message.push(`${needTriage} issues that need triage`);
@@ -57,22 +68,29 @@ const repoSummaries = repos.map((repo) => {
         if (urgent > 0) {
             message.push(`${urgent} urgent issues`);
         }
-    } else if (soon > 0) {
-        message.push(`${soon} soon-priority issues`);
+    } else if (soon > 0 || agenda > 0) {
+        if (soon > 0) {
+            message.push(`${soon} soon-priority issues`);
+        }
+        if (agenda > 0) {
+            message.push(`${agenda} issues on the agenda`);
+        }
     }
 
     return Object.assign({}, repo, {
         triageViolations,
         urgentViolations,
         soonViolations,
+        agendaViolations,
         needTriage,
         urgent,
         soon,
+        agenda,
         other,
         class_:
             triageViolations > 0 || urgentViolations > 0
                 ? "error"
-                : soonViolations > 0
+                : soonViolations > 0 || agendaViolations > 0
                   ? "warning"
                   : "",
         message: andFormatter.format(message),
@@ -88,12 +106,15 @@ function sortKey(summary: (typeof repoSummaries)[0]): {
             priority: 4,
             count: summary.triageViolations + summary.urgentViolations,
         };
-    } else if (summary.soonViolations > 0) {
-        return { priority: 3, count: summary.soonViolations };
+    } else if (summary.soonViolations > 0 || summary.agendaViolations > 0) {
+        return {
+            priority: 3,
+            count: summary.soonViolations + summary.agendaViolations,
+        };
     } else if (summary.needTriage > 0 || summary.urgent > 0) {
         return { priority: 2, count: summary.needTriage + summary.urgent };
-    } else if (summary.soon > 0) {
-        return { priority: 1, count: summary.soon };
+    } else if (summary.soon > 0 || summary.agenda > 0) {
+        return { priority: 1, count: summary.soon + summary.agenda };
     } else {
         return { priority: 0, count: summary.other };
     }
@@ -119,8 +140,8 @@ repoSummaries.sort(compareByKey);
         <p>For now, this page sets SLOs of:</p>
         <ul>
             <li>
-                7 days to triage an issue. An issue counts as triaged if any of
-                the "Priority" or "Agenda+" <a
+                {triageSLO.days} days to triage an issue. An issue counts as triaged
+                if any of the "Priority" or "Agenda+" <a
                     href={`${import.meta.env.BASE_URL}triage-labels`}
                     >triage labels</a
                 > are applied. If a repository doesn't have the
@@ -128,9 +149,18 @@ repoSummaries.sort(compareByKey);
                 as triaged once it's assigned to a milestone or someone other than
                 the original author comments.
             </li>
-            <li>14 days to close a <GhLabel {...ghLabels.urgent} /> issue.</li>
             <li>
-                91 days to close a <GhLabel {...ghLabels.soon} /> issue.
+                {urgentSLO.days} days to close a <GhLabel
+                    {...ghLabels.urgent}
+                /> issue.
+            </li>
+            <li>
+                {soonSLO.days} days to close a <GhLabel {...ghLabels.soon} /> issue.
+            </li>
+            <li>
+                {agendaSLO.days} days to have a discussion about an <GhLabel
+                    {...ghLabels.agenda}
+                /> issue.
             </li>
         </ul>
 
@@ -160,12 +190,25 @@ repoSummaries.sort(compareByKey);
                 ) : null
             }
             {
+                totalAgendaViolations > 0 ? (
+                    <li class="warning">
+                        {totalAgendaViolations} issues on the agenda outside of
+                        their SLO
+                    </li>
+                ) : null
+            }
+            {
                 totalNeedTriage > 0 ? (
                     <li>{totalNeedTriage} issues that need triage</li>
                 ) : null
             }
             {totalUrgent > 0 ? <li>{totalUrgent} urgent issues</li> : null}
             {totalSoon > 0 ? <li>{totalSoon} soon-priority issues</li> : null}
+            {
+                totalAgenda > 0 ? (
+                    <li>{totalAgenda} issues on the agenda</li>
+                ) : null
+            }
             {totalOther > 0 ? <li>{totalOther} other issues</li> : null}
         </ul>
 

--- a/frontend/src/pages/slo.csv.ts
+++ b/frontend/src/pages/slo.csv.ts
@@ -16,10 +16,12 @@ export const GET: APIRoute = async () => {
             Retrieved: repoData.cachedAt.round("second").toString(),
             'Need Triage': groups.untriaged.length,
             'Triage Violations': groups.triageViolations.length,
+            'Agenda Violations': groups.agendaViolations.length,
             Urgent: groups.urgent.length,
             'Urgent Violations': groups.urgentViolations.length,
             Soon: groups.soon.length,
             'Soon Violations': groups.soonViolations.length,
+            Agenda: groups.agenda.length,
             Other: groups.other.length,
         };
     });

--- a/frontend/src/pages/slo.json.ts
+++ b/frontend/src/pages/slo.json.ts
@@ -14,9 +14,11 @@ export const GET: APIRoute = async () => {
             triageViolations: groups.triageViolations.length,
             urgentViolations: groups.urgentViolations.length,
             soonViolations: groups.soonViolations.length,
+            agendaViolations: groups.agendaViolations.length,
             needTriage: groups.untriaged.length,
             urgent: groups.urgent.length,
             soon: groups.soon.length,
+            agenda: groups.agenda.length,
             other: groups.other.length,
         }];
     })) satisfies SummaryJson;

--- a/frontend/src/pages/triage-labels.astro
+++ b/frontend/src/pages/triage-labels.astro
@@ -1,7 +1,11 @@
 ---
 import GhLabel from "@components/GhLabel.astro";
+import { Temporal } from "@js-temporal/polyfill";
+import { agendaSLO, soonSLO, urgentSLO } from "@lib/slo";
 import * as ghLabels from "@lib/triage-labels.js";
 import Layout from "../layouts/Layout.astro";
+
+const today = Temporal.Now.plainDateISO();
 ---
 
 <Layout title="Triage Labels">
@@ -15,13 +19,17 @@ import Layout from "../layouts/Layout.astro";
             <dt><GhLabel {...ghLabels.urgent} /></dt>
             <dd>
                 Needs to be resolved more quickly than other issues. These
-                issues and PRs are expected to be resolved within 14 days.
+                issues and PRs are expected to be resolved within {
+                    urgentSLO.days
+                } days.
             </dd>
             <dt><GhLabel {...ghLabels.soon} /></dt>
             <dd>
                 Needs to be resolved within a reasonable timeframe, but not as
                 quickly as urgent issues. These issues and PRs are expected to
-                be resolved within 3 months.
+                be resolved within {
+                    soonSLO.round({ smallestUnit: "month", relativeTo: today }).months
+                } months.
             </dd>
             <dt><GhLabel {...ghLabels.eventually} /></dt>
             <dd>Doesn't need to be resolved within a particular time limit.</dd>
@@ -33,8 +41,12 @@ import Layout from "../layouts/Layout.astro";
             </dd>
             <dt><GhLabel {...ghLabels.agenda} /></dt>
             <dd>
-                Treated the same as <GhLabel {...ghLabels.soon} /> for SLO purposes,
-                but also implies that the issue needs to be discussed in a real-time meeting.
+                The issue needs a real-time discussion, often at a working group
+                meeting. These issues and PRs are expected to be discussed
+                within {
+                    agendaSLO.round({ smallestUnit: "week", relativeTo: today }).weeks
+                } weeks, at which point the label will be removed, but the issue
+                won't necessarily be closed.
             </dd>
         </dl>
     </main>


### PR DESCRIPTION
* Initially give agenda items a 5-week SLO.
* Count agenda time from the last time an issue was added to the agenda, unlike other SLOs that count the total time the relevant label was applied.


FYI @fantasai, @svgeesus, @tabatkins, no need to review in detail, but I'd love your overall impression, especially about whether a 5-week goal for discussing agenda items makes sense and if you'd like the data presented in a different way. This makes the csswg-drafts page look roughly like
![Screenshot of the csswg spec-maintenance summary showing an Agenda section with several out-of-SLO items and more within-SLO items](https://github.com/speced/spec-maintenance/assets/83420/a92da343-97be-4a5d-8f78-45064dc9e515)
