### PR TITLE
Give the CSSWG a custom triage heuristic.

### DIFF
--- a/scanner/github.ts
+++ b/scanner/github.ts
@@ -329,6 +329,7 @@ export async function fetchAllComments(needAllComments: IssueOrPr[], needEarlyCo
 }
 
 const Repository = z.object({
+  nameWithOwner: z.string(),
   labels: z.object({
     totalCount: z.number(),
     nodes: z.array(z.object({
@@ -346,6 +347,7 @@ export async function getRepo(org, repo): Promise<Repository> {
   const result = RepositoryQueryResult.parse(await octokit.graphql(
     gql(`query ($owner: String!, $repoName: String!) {
       repository(owner: $owner, name: $repoName) {
+        nameWithOwner
         labels(first: 100, query: "Priority") {
           totalCount
           nodes {

--- a/scanner/main.ts
+++ b/scanner/main.ts
@@ -59,7 +59,7 @@ async function analyzeRepo(org: string, repoName: string, globalStats: GlobalSta
         author: issue.author?.login,
         createdAt: issue.createdAt,
         sloTimeUsed: Temporal.Duration.from({ seconds: 0 }),
-        whichSlo: whichSlo(issue),
+        whichSlo: whichSlo(repo.nameWithOwner, issue),
         onAgendaFor: countAgendaTime(issue, now),
         labels: issue.labels.nodes.map(label => label.name),
         stats: {

--- a/scanner/per-repo.ts
+++ b/scanner/per-repo.ts
@@ -1,0 +1,18 @@
+import { IssueOrPr } from "./github.js";
+
+const triagePredicates: Record<`${string}/${string}`, (issue: Pick<IssueOrPr, 'labels'>) => boolean> = {
+    'w3c/csswg-drafts': function (issue: Pick<IssueOrPr, 'labels'>) {
+        return issue.labels.nodes.length > 0;
+    },
+};
+
+// True if this repository has configured a custom function to say whether an issue is triaged
+// without an SLO, instead of the common `Priority: Eventually` label.
+export function hasTriagePredicate(repoNameWithOwner: string) {
+    return repoNameWithOwner in triagePredicates;
+}
+
+// True if this issue should be considered triaged without an SLO.
+export function isTriaged(repoNameWithOwner: string, issue: Pick<IssueOrPr, 'labels'>): boolean {
+    return triagePredicates[repoNameWithOwner]?.(issue);
+}


### PR DESCRIPTION
Since they don't have any auto-labeling system or
issue templates, if an issue has a label, then
someone with the ability to triage it has touched
it, so we can consider it triaged.

Fixes #22. 

@fantasai, @astearns, this takes CSS from 733 untriaged issues to 51. Does this seem like the right change to make instead of marking all open issues with `Priority: Eventually`?

https://speced.github.io/spec-maintenance/w3c/csswg-drafts/ vs 

## [w3c/csswg-drafts Issues](https://github.com/w3c/csswg-drafts/issues)
- [51 out-of-SLO untriaged issues](http://localhost:4321/w3c/csswg-drafts#untriaged)
- [10 issues on the agenda that have been waiting too long](http://localhost:4321/w3c/csswg-drafts#agenda)

## Untriaged

- [Add 'Privacy and Security Considerations' section](https://github.com/w3c/csswg-drafts/issues/207): out of SLO for 7.7 years
- [Using `<i>` elements as `<dfn>` autolinks](https://github.com/w3c/csswg-drafts/issues/1230): out of SLO for 6.9 years
- [[extend-rule] ](https://github.com/w3c/csswg-drafts/issues/1855): out of SLO for 6.4 years
- [CSSWG specs need usable test suite docs](https://github.com/w3c/csswg-drafts/issues/2438): out of SLO for 6 years
- [[css-???] Standardise a binary representation for CSS](https://github.com/w3c/csswg-drafts/issues/3334): out of SLO for 5.3 years
- [Small problems with CSS, JAVA & HTML that seems not possible without photo editor](https://github.com/w3c/csswg-drafts/issues/3738): out of SLO for 4.9 years
- [Separation of style and content](https://github.com/w3c/csswg-drafts/issues/3778): out of SLO for 4.9 years
- [Composing class names inside media queries](https://github.com/w3c/csswg-drafts/issues/4040): out of SLO for 4.7 years
- [[css-icon] CSS isn't used for icons - it should be](https://github.com/w3c/csswg-drafts/issues/4295): out of SLO for 4.5 years
- [Need a definition for what it means for something to be painted on screen](https://github.com/w3c/csswg-drafts/issues/4825): out of SLO for 4 years
- [[resize-observer-1] Invoke callback with observer as 2nd argument and `this` value](https://github.com/w3c/csswg-drafts/pull/5383): out of SLO for 3.6 years
- [[web-animations-1] Add hold phase to animation #4325](https://github.com/w3c/csswg-drafts/pull/5479): out of SLO for 3.5 years
- [[css-animations-2] Describe behavior for changes to animation-timeline](https://github.com/w3c/csswg-drafts/pull/5666): out of SLO for 3.3 years
- [[css-transforms-1] Fix mistakes in Example 5 (closes #4767)](https://github.com/w3c/csswg-drafts/pull/5690): out of SLO for 3.3 years
- [[css-transforms-1] Fix 5520](https://github.com/w3c/csswg-drafts/pull/5702): out of SLO for 3.3 years
- [[scroll-animations-1] Specify liveness of element references](https://github.com/w3c/csswg-drafts/pull/5751): out of SLO for 3.2 years
- [[css-font-loading-3] Remove unused ForEachCallback](https://github.com/w3c/csswg-drafts/pull/5785): out of SLO for 3.2 years
- [[css-cascade-5] Fix cross-link to CSSOM-1 for "final CSS style sheets" concept](https://github.com/w3c/csswg-drafts/pull/6497): out of SLO for 2.6 years
- [[css-transitions-1] Define before/after-change style in terms of base](https://github.com/w3c/csswg-drafts/pull/6688): out of SLO for 2.4 years
- [[css-pseudo-4] [css-highlight-api-1] Integrate custom highlights into css-pseudo-4](https://github.com/w3c/csswg-drafts/pull/6754): out of SLO for 2.3 years
- [A proposal for controlling screen brightness](https://github.com/w3c/csswg-drafts/issues/6990): out of SLO for 2.1 years
- [CSS Toggles Proposal](https://github.com/w3c/csswg-drafts/issues/6991): out of SLO for 2.1 years
- [[css-toggle] scope enum bikeshed: change from narrow/wide to shallow/deep](https://github.com/w3c/csswg-drafts/issues/7008): out of SLO for 2.1 years
- [Give authors the ability to style form validation messages](https://github.com/w3c/csswg-drafts/issues/7172): out of SLO for 1.9 years
- [[mediaqueries-5] Move the definition of display-mode back to APPMANIFEST. Closes #7306.](https://github.com/w3c/csswg-drafts/pull/7307): out of SLO for 1.8 years
- [[css-nav-1] Scope event definition to target interface](https://github.com/w3c/csswg-drafts/pull/7443): out of SLO for 1.7 years
- [[css-scoping-module]: host-selector specificity replication removal](https://github.com/w3c/csswg-drafts/pull/7611): out of SLO for 1.5 years
- [Define guidelines for preprocessors, libraries, frameworks](https://github.com/w3c/csswg-drafts/issues/7150): out of SLO for 1.5 years
- [[css-contain-2] Improve definition of contentvisibilityautostatechange event](https://github.com/w3c/csswg-drafts/pull/7740): out of SLO for 1.5 years
- [[css-contain-2] Adds missing attribute values. ](https://github.com/w3c/csswg-drafts/pull/8033): out of SLO for 1.3 years
- [[resize-observer] Update initial value of lastReportedSizes #3664](https://github.com/w3c/csswg-drafts/pull/8125): out of SLO for 1.3 years
- [why mediaqueries?](https://github.com/w3c/csswg-drafts/issues/8472): out of SLO for 1 year
- [[css-scroll-snap-2] scroll-start clamps to scroll range not scrollpor…](https://github.com/w3c/csswg-drafts/pull/8908): out of SLO for 8.9 months
- [Allow authors to configure a few settings from within CSS (CSS `@config`)](https://github.com/w3c/csswg-drafts/issues/9109): out of SLO for 7.1 months
- [[css-contain-3] Define the block contents of `@container` with `<rule-list>`](https://github.com/w3c/csswg-drafts/pull/9215): out of SLO for 6.2 months
- [[web-animations-1] Define 'start time' for animation effects](https://github.com/w3c/csswg-drafts/pull/9219): out of SLO for 6.2 months
- [[selectors-4] Replace :user-valid/:user-invalid definition with HTML spec](https://github.com/w3c/csswg-drafts/pull/9308): out of SLO for 5.7 months
- [[web-animation-2] Avoid using a dictionary for range in animation IDL](https://github.com/w3c/csswg-drafts/pull/9360): out of SLO for 5.4 months
- [[css-pseudo-4] Add discussion of properties from the originating element](https://github.com/w3c/csswg-drafts/pull/9428): out of SLO for 4.9 months
- [[css-syntax-3] Rename `<an+b>` to `<an-b>`](https://github.com/w3c/csswg-drafts/pull/9480): out of SLO for 4.4 months
- [[css-cascade-5] page and view-transition at rules should cascade](https://github.com/w3c/csswg-drafts/pull/9604): out of SLO for 3.4 months
- [[css-logical] Add `block-start` and `block-end` values to `caption-side` property](https://github.com/w3c/csswg-drafts/pull/9620): out of SLO for 3.2 months
- [[css-pseudo-4] Clarify text decorations in ::spelling-error and ::grammar-error](https://github.com/w3c/csswg-drafts/pull/9633): out of SLO for 3.1 months
- [[cssom-view] Add 'onmove' event handler for the Window object](https://github.com/w3c/csswg-drafts/pull/9664): out of SLO for 2.9 months
- [[css-view-transitions-1] Defer restoring persisted state until after capturing old state](https://github.com/w3c/csswg-drafts/pull/9676): out of SLO for 2.8 months
- [[cssom] [css-fonts] [css-page] Sort out properties and descriptors.](https://github.com/w3c/csswg-drafts/pull/9686): out of SLO for 2.6 months
- [[css-shapes][editorial] Define production rule for `<basic-shape>`](https://github.com/w3c/csswg-drafts/pull/9727): out of SLO for 2.3 months
- [[css-shapes-2]: apply minor comments to `shape()` syntax](https://github.com/w3c/csswg-drafts/pull/9797): out of SLO for 1.4 months
- [New property to control the direction of slider controls](https://github.com/w3c/csswg-drafts/issues/9832): out of SLO for 1.2 months
- [improve styling of `<details>`/`<summary>` elements](https://github.com/w3c/csswg-drafts/issues/9879): out of SLO for 3.9 weeks
- [[css-sizing-4] Define stretch sizing properly, rather than (incorrectly) indirecting thru stretch alignment.](https://github.com/w3c/csswg-drafts/pull/9902): out of SLO for 3.4 weeks
- [[cssom-1] Simplify setting MediaList.mediaText](https://github.com/w3c/csswg-drafts/pull/10014): on maintainers' plate for 4 days
- [[css-ui] Changing UA styles based on the computed value of the appearance property](https://github.com/w3c/csswg-drafts/issues/10028): on maintainers' plate for 4 hours
- [`css-color` unspecified target contrast ratios with `contrast-color()` should use the users preference ](https://github.com/w3c/csswg-drafts/issues/10029): on maintainers' plate for 2 hours
