### PR TITLE
Flag when a group has too many issues on their agenda.

### DIFF
--- a/frontend/src/layouts/Layout.astro
+++ b/frontend/src/layouts/Layout.astro
@@ -14,7 +14,17 @@ const { title } = Astro.props;
         <meta name="generator" content={Astro.generator} />
         <title>{title}</title>
         <style is:global>
-            body {max-width: 50em;}
+            body {
+                max-width: 50em;
+            }
+            :is(li, dd) {
+                & > p:first-child {
+                    margin-top: 0;
+                }
+                & > p:last-child {
+                    margin-bottom: 0;
+                }
+            }
         </style>
     </head>
     <body>

--- a/frontend/src/lib/slo.ts
+++ b/frontend/src/lib/slo.ts
@@ -10,6 +10,9 @@ export const soonSLO = Temporal.Duration.from({ days: 91 });
 // once.
 export const agendaSLO = Temporal.Duration.from({ days: 35 });
 
+// Keep to at most 25 agenda items.
+export const agendaLengthSLO = 25;
+
 export const sloMap = {
     "urgent": urgentSLO,
     "soon": soonSLO,

--- a/frontend/src/pages/[org]/[repo].astro
+++ b/frontend/src/pages/[org]/[repo].astro
@@ -5,6 +5,7 @@ import Issue from "@components/Issue.astro";
 import Layout from "@layouts/Layout.astro";
 import { IssueSummary } from "@lib/repo-summaries";
 import {
+agendaLengthSLO,
 agendaSLO,
 cmpByAgendaUsed,
 cmpByTimeUsed,
@@ -101,9 +102,12 @@ untriaged.sort(cmpByTimeUsed);
             agenda.length > 0 ? (
                 <li>
                     <a href="#agenda">
-                        {agendaViolations.length
-                            ? `${agendaViolations.length} issues on the agenda that have been waiting too long`
-                            : `${agenda.length} issues on the agenda`}
+                        {agenda.length > agendaLengthSLO &&
+                        agendaViolations.length
+                            ? `${agenda.length} issues on the agenda, ${agendaViolations.length} of which have been waiting too long; consider scheduling more meetings`
+                            : agendaViolations.length
+                              ? `${agendaViolations.length} issues on the agenda that have been waiting too long`
+                              : `${agenda.length} issues on the agenda${agenda.length > agendaLengthSLO ? "; consider scheduling more meetings" : ""}`}
                     </a>
                 </li>
             ) : null
@@ -169,7 +173,8 @@ untriaged.sort(cmpByTimeUsed);
             <>
                 <h2 id="agenda">Agenda</h2>
                 <p>
-                    Try to discuss
+                    Try to maintain fewer than {agendaLengthSLO} agenda items
+                    and discuss
                     {/* prettier-ignore */}
                     <a href={`${import.meta.env.BASE_URL}about#agenda`}>issues
                         on the agenda</a>

--- a/frontend/src/pages/about.astro
+++ b/frontend/src/pages/about.astro
@@ -1,7 +1,13 @@
 ---
 import Duration from "@components/Duration.astro";
 import GhLabel from "@components/GhLabel.astro";
-import { agendaSLO, soonSLO, triageSLO, urgentSLO } from "@lib/slo";
+import {
+agendaLengthSLO,
+agendaSLO,
+soonSLO,
+triageSLO,
+urgentSLO,
+} from "@lib/slo";
 import * as ghLabels from "@lib/triage-labels";
 import Layout from "../layouts/Layout.astro";
 ---
@@ -101,15 +107,21 @@ import Layout from "../layouts/Layout.astro";
         <dl>
             <dt id="agenda">On the agenda</dt>
             <dd>
-                An issue labeled <GhLabel {...ghLabels.agenda} /> should be discussed
-                and have the label removed within <b
-                    ><Duration d={agendaSLO} /></b
-                >. The <a
-                    href="https://en.wikipedia.org/wiki/Service_level_indicator"
-                    ><abbr title="Service Level Indicator">SLI</abbr></a
-                > for handling agenda items only counts the current application of
-                this label, unlike priorities which include previous times their
-                label was added and then removed.
+                <p>
+                    An issue labeled <GhLabel {...ghLabels.agenda} /> should be discussed
+                    and have the label removed within <b
+                        ><Duration d={agendaSLO} /></b
+                    >. The <a
+                        href="https://en.wikipedia.org/wiki/Service_level_indicator"
+                        ><abbr title="Service Level Indicator">SLI</abbr></a
+                    > for handling agenda items only counts the current application
+                    of this label, unlike priorities which include previous times
+                    their label was added and then removed.
+                </p>
+                <p>
+                    Groups should have enough meetings to keep their agendas
+                    below {agendaLengthSLO} items.
+                </p>
             </dd>
         </dl>
     </main>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import GhLabel from "@components/GhLabel.astro";
 import { IssueSummary } from "@lib/repo-summaries";
-import { groupBySlo } from "@lib/slo";
+import { agendaLengthSLO, groupBySlo } from "@lib/slo";
 import * as ghLabels from "@lib/triage-labels";
 import { getCollection } from "astro:content";
 import Layout from "../layouts/Layout.astro";
@@ -17,6 +17,7 @@ let totalUrgent = 0;
 let totalSoon = 0;
 let totalAgenda = 0;
 let totalOther = 0;
+let totalGroupsOverAgendaLimit = 0;
 
 const andFormatter = new Intl.ListFormat("en", {
     style: "long",
@@ -45,21 +46,34 @@ const repoSummaries = repos.map((repo) => {
     totalSoon += soon;
     totalAgenda += agenda;
     totalOther += other;
+    if (agenda + agendaViolations > agendaLengthSLO) {
+        totalGroupsOverAgendaLimit++;
+    }
 
     let message: string[] = [];
+    let class_ = "";
     if (triageViolations > 0 || urgentViolations > 0) {
+        class_ = "error";
         if (triageViolations > 0) {
             message.push(`${triageViolations} triage SLO violations`);
         }
         if (urgentViolations > 0) {
             message.push(`${urgentViolations} urgent SLO violations`);
         }
-    } else if (soonViolations > 0 || agendaViolations > 0) {
+    } else if (
+        soonViolations > 0 ||
+        agendaViolations > 0 ||
+        agenda + agendaViolations > agendaLengthSLO
+    ) {
+        class_ = "warning";
         if (soonViolations > 0) {
             message.push(`${soonViolations} soon SLO violations`);
         }
         if (agendaViolations > 0) {
             message.push(`${agendaViolations} agenda SLO violations`);
+        }
+        if (agenda + agendaViolations > agendaLengthSLO) {
+            message.push(`${agenda + agendaViolations} issues on the agenda`);
         }
     } else if (needTriage > 0 || urgent > 0) {
         if (needTriage > 0) {
@@ -87,12 +101,7 @@ const repoSummaries = repos.map((repo) => {
         soon,
         agenda,
         other,
-        class_:
-            triageViolations > 0 || urgentViolations > 0
-                ? "error"
-                : soonViolations > 0 || agendaViolations > 0
-                  ? "warning"
-                  : "",
+        class_,
         message: andFormatter.format(message),
     });
 });
@@ -106,10 +115,21 @@ function sortKey(summary: (typeof repoSummaries)[0]): {
             priority: 4,
             count: summary.triageViolations + summary.urgentViolations,
         };
-    } else if (summary.soonViolations > 0 || summary.agendaViolations > 0) {
+    } else if (
+        summary.soonViolations > 0 ||
+        summary.agendaViolations > 0 ||
+        summary.agenda + summary.agendaViolations > agendaLengthSLO
+    ) {
+        let agendaIfTooMany = 0;
+        if (summary.agenda + summary.agendaViolations > agendaLengthSLO) {
+            agendaIfTooMany = summary.agenda;
+        }
         return {
             priority: 3,
-            count: summary.soonViolations + summary.agendaViolations,
+            count:
+                summary.soonViolations +
+                summary.agendaViolations +
+                agendaIfTooMany,
         };
     } else if (summary.needTriage > 0 || summary.urgent > 0) {
         return { priority: 2, count: summary.needTriage + summary.urgent };
@@ -171,6 +191,14 @@ repoSummaries.sort(compareByKey);
                 ) : null
             }
             {
+                totalGroupsOverAgendaLimit > 0 ? (
+                    <li class="warning">
+                        {totalGroupsOverAgendaLimit} group(s) with too many issues
+                        on the agenda
+                    </li>
+                ) : null
+            }
+            {
                 totalNeedTriage > 0 ? (
                     <li>{totalNeedTriage} issues that need triage</li>
                 ) : null
@@ -192,7 +220,7 @@ repoSummaries.sort(compareByKey);
                         <dt>
                             <a href={`${repo.data.org}/${repo.data.repo}`}>
                                 {repo.data.org}/{repo.data.repo}
-                            </a>{" "}
+                            </a>
                             {repo.data.labelsPresent ? null : (
                                 <>
                                     (no <GhLabel {...ghLabels.eventually} />


### PR DESCRIPTION
Fixes #25 and looks like

!["60 issues on the agenda, 10 of which have been waiting too long; consider scheduling more meetings"](https://github.com/speced/spec-maintenance/assets/83420/741014ea-30a7-456e-8f27-1b18b5be303c)

I could make this louder, but I think I'd want a matching increase in the out-of-SLO volumes too, and my engineer's design sense fell over when I thought about making links red. Any thoughts @fantasai, @svgeesus, @astearns?